### PR TITLE
Add CLI wordlist loader and passphrase

### DIFF
--- a/kernel/common.cl
+++ b/kernel/common.cl
@@ -16,14 +16,17 @@
   (a)[7] ^= (b)[7];
 
 
-#define DEBUG_ARRAY(name, array, len)                                          \
-  do {                                                                         \
-    for (uint i = 0; i < (len); i++) {                                         \
-      printf("%s[%d] = 0x%016lxUL\n",name,i, (array)[i]);                                       \
-    }                                                                          \
-                                                                  \
-  } while (0)
 
+#ifdef DEBUG_PRINTF
+#define DEBUG_ARRAY(name, array, len) \
+  do { \
+    for (uint i = 0; i < (len); i++) { \
+      printf("%s[%d] = 0x%016lxUL\n", name, i, (array)[i]); \
+    } \
+  } while (0)
+#else
+#define DEBUG_ARRAY(name, array, len)
+#endif
 uint strlen(uchar *s) {
   uint l;
   for (l = 0; s[l] != '\0'; l++) {

--- a/readme.md
+++ b/readme.md
@@ -135,3 +135,13 @@ Feel free to contribute, suggest improvements, or open an issue if you have any 
 	email[@]brunodasilva.com
     2024
 
+
+## Usage
+
+Run the script with your anchor and unknown word files:
+
+```bash
+python3 main.py --anchors anchors.json --unknowns unknowns.json --passphrase 1713
+```
+
+`anchors.json` contains fixed or guessed words with their indices. `unknowns.json` maps remaining positions to candidate word lists. The passphrase is optional and defaults to an empty string.

--- a/wallets.tsv
+++ b/wallets.tsv
@@ -1,0 +1,2 @@
+address	balance
+1ExampleAddress	0.0


### PR DESCRIPTION
## Summary
- convert main.py to argparse-based CLI
- load anchors and unknown word guesses from JSON
- compute PBKDF2 salt data for a custom passphrase
- guard debug printing in kernels
- provide sample wallets.tsv and usage docs

## Testing
- `python3 -m py_compile main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*